### PR TITLE
Fix typos in installer.sh

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -49,7 +49,7 @@ fi
 
 
 SECONDARY_COMMAND="gnos"
-if [[ $# -gt 1 && ($2 == "gooe" || $2 == "igo" || $2 == "all" || $2 == "gnos" || $2 == 'jigo") ]]
+if [[ $# -gt 1 && ($2 == "gooe" || $2 == "igo" || $2 == "all" || $2 == "gnos" || $2 == "jigo") ]]
   then
   SECONDARY_COMMAND=$2
 fi
@@ -67,7 +67,6 @@ elif [[ $SECONDARY_COMMAND == "gnos" ]]
 elif [[ $SECONDARY_COMMAND == "jigo" ]]
   then
   font_installs=("jigo")
-fi
 fi
 
 texhome=$(kpsewhich -var-value TEXMFHOME)


### PR DESCRIPTION
has a ' instead of a ", and an extra 'fi'.  Current version runs but doesn't work, error:

"ERROR:  The following map file(s) couldn't be found:
	jigo.map (in /Users/...snip.../Library/texlive/2014/texmf-config/web2c/updmap.cfg)

	Did you run mktexlsr?

	You can disable non-existent map entries using the option
	  --syncwithtrees.
"